### PR TITLE
feat: Add build script for publishing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /node_modules
 public/build
+build/*
 package-lock.json
 
 # Tests
@@ -7,3 +8,4 @@ package-lock.json
 /playwright-report/
 /blob-report/
 /playwright/.cache/
+

--- a/README.md
+++ b/README.md
@@ -21,19 +21,19 @@ Web component created using [lit](https://lit.dev/)
 1. Copy and paste the following code inside the `<body></body>` tag of website where the component should appear, replacing `GOOGLE-API-KEY` with your key
 
 ```
-<alpaca-map key="GOOGLE-API-KEY"></alpaca-map>
+<alpaca-map apiKey="GOOGLE-API-KEY"></alpaca-map>
 ```
 
 1. Optional. To center the map on a favourite farm, replace the latitude and longitude with its `centerLat` and `centerLng` coordinates
 
 ```
-   <alpaca-map key="GOOGLE-API-KEY" centerLat="-33.8688" centerLng="151.2093"></alpaca-map>
+   <alpaca-map apiKey="GOOGLE-API-KEY" centerLat="-33.8688" centerLng="151.2093"></alpaca-map>
 ```
 
 1. Optional. To override the data source, set the value of `dataSource`, eg
 
 ```
-   <alpaca-map key="GOOGLE-API-KEY" dataSource="https://www.replace-me.com/api/cool-api"></alpaca-map>
+   <alpaca-map apiKey="GOOGLE-API-KEY" dataSource="https://www.replace-me.com/api/cool-api"></alpaca-map>
 ```
 
 ## For developers 🤖

--- a/dev-utils/dev-build.js
+++ b/dev-utils/dev-build.js
@@ -1,0 +1,49 @@
+import rollupPluginCommonjs from "@rollup/plugin-commonjs";
+import rollupPluginResolve from "@rollup/plugin-node-resolve";
+import rollupPluginReplace from "@rollup/plugin-replace";
+import rollupPluginTerser from "@rollup/plugin-terser";
+import { rollup } from "rollup";
+
+const inputOptions = {
+  input: ["./src/alpaca-map.js"],
+  plugins: [
+    rollupPluginResolve({ 
+      preferBuiltins: true 
+    }),
+    rollupPluginCommonjs({ 
+      include: /node_modules/ 
+    }),
+    rollupPluginReplace({
+      "process.env.NODE_ENV": JSON.stringify("production"),
+      preventAssignment: true,
+    }),
+    /*
+    rollupPluginTerser({ 
+      format: { 
+        comments: false 
+      } 
+    }),
+    */
+  ],
+};
+
+const outputOptionsList = [
+  {
+    preserveModules: true,
+    dir: './public/build',
+    // file: "./public/build/alpaca-map.js",
+    format: "es",
+    // sourcemap: true,
+    interop: 'esModule',
+  },
+];
+
+let bundle = await rollup(inputOptions);
+
+for (const outputOptions of outputOptionsList) {
+  await bundle.write(outputOptions);
+}
+
+if (bundle) {
+  await bundle.close();
+}

--- a/dev-utils/dev-server.js
+++ b/dev-utils/dev-server.js
@@ -8,7 +8,7 @@ const fastify = Fastify({
 });
 
 fastify.register(fastifyStatic, {
-  root: path.join(import.meta.dirname, "./public"),
+  root: path.join(import.meta.dirname, "../public"),
   prefix: "/",
 });
 

--- a/dev-utils/pub-build.js
+++ b/dev-utils/pub-build.js
@@ -1,29 +1,32 @@
 import rollupPluginCommonjs from "@rollup/plugin-commonjs";
 import rollupPluginResolve from "@rollup/plugin-node-resolve";
 import rollupPluginReplace from "@rollup/plugin-replace";
-import rollupPluginTerser from "@rollup/plugin-terser";
 import { rollup } from "rollup";
 
 const inputOptions = {
   input: ["./src/alpaca-map.js"],
+  external: ['lit'],
   plugins: [
-    rollupPluginResolve({ preferBuiltins: true }),
-    rollupPluginCommonjs({ include: /node_modules/ }),
+    rollupPluginResolve({ 
+      preferBuiltins: true 
+    }),
+    rollupPluginCommonjs({ 
+      include: /node_modules/ 
+    }),
     rollupPluginReplace({
       "process.env.NODE_ENV": JSON.stringify("production"),
       preventAssignment: true,
     }),
-    rollupPluginTerser({ format: { comments: false } }),
   ],
 };
 
 const outputOptionsList = [
   {
-    // preserveModules: true,
-    // dir: './public/build',
-    file: "./public/build/alpaca-map.js",
+    preserveModules: true,
+    entryFileNames: '[name].mjs',
+    dir: './build/node',
     format: "es",
-    sourcemap: true,
+    interop: 'esModule',
   },
 ];
 

--- a/dev-utils/pub-build.js
+++ b/dev-utils/pub-build.js
@@ -8,6 +8,7 @@ const inputOptions = {
   external: ['lit'],
   plugins: [
     rollupPluginResolve({ 
+      exportConditions: ['production'],
       preferBuiltins: true 
     }),
     rollupPluginCommonjs({ 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "prettier": "prettier . --write",
     "start": "node ./dev-utils/dev-server.js",
     "test": "node --test",
-    "test-ui": "playwright test"
+    "test-ui": "playwright test",
+    "prepublishOnly": "npm run build:publish:node"
   },
   "author": "",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -2,17 +2,21 @@
   "name": "@purplebugs/alpaca-map",
   "type": "module",
   "version": "0.0.4",
-  "main": "src/alpaca-map.js",
+  "exports": {
+    ".": "./build/node/src/alpaca-map.mjs"
+  },
   "files": [
     "package.json",
     "README.md",
+    "build",
     "src"
   ],
   "scripts": {
-    "build:watch": "node --watch-path=./src build.js",
-    "build": "node build.js",
+    "build:publish:node": "node ./dev-utils/pub-build.js",
+    "build:watch": "node --watch-path=./src ./dev-utils/dev-build.js",
+    "build": "node ./dev-utils/dev-build.js",
     "prettier": "prettier . --write",
-    "start": "node dev-server.js",
+    "start": "node ./dev-utils/dev-server.js",
     "test": "node --test",
     "test-ui": "playwright test"
   },
@@ -20,19 +24,19 @@
   "license": "MIT",
   "description": "",
   "devDependencies": {
+    "@googlemaps/markerclusterer": "^2.5.3",
     "@fastify/static": "7.0.4",
     "@playwright/test": "^1.45.1",
     "@rollup/plugin-commonjs": "26.0.1",
     "@rollup/plugin-node-resolve": "15.2.3",
     "@rollup/plugin-replace": "5.0.7",
     "@rollup/plugin-terser": "0.4.4",
-    "@types/node": "^20.14.10",
-    "fastify": "4.28.0",
-    "prettier": "3.3.2",
-    "rollup": "4.18.0"
+    "@types/node": "20.14.10",
+    "fastify": "4.28.1",
+    "prettier": "3.3.3",
+    "rollup": "4.21.3"
   },
   "dependencies": {
-    "@googlemaps/markerclusterer": "^2.5.3",
     "lit": "^3.1.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "license": "MIT",
   "description": "",
   "devDependencies": {
+    "@googlemaps/js-api-loader": "1.16.8",
     "@googlemaps/markerclusterer": "^2.5.3",
     "@fastify/static": "7.0.4",
     "@playwright/test": "^1.45.1",
@@ -37,6 +38,6 @@
     "rollup": "4.21.3"
   },
   "dependencies": {
-    "lit": "^3.1.4"
+    "lit": "3.1.4"
   }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -31,7 +31,7 @@
         <alpaca-map key="AIzaSyB4xD7fB993xNwqzBwF0vFpV3Qg_N9UTTc" centerLat="-33.8688" centerLng="151.2093"></alpaca-map>
      -->
 
-      <alpaca-map key="AIzaSyB4xD7fB993xNwqzBwF0vFpV3Qg_N9UTTc"></alpaca-map>
+      <alpaca-map apiKey="AIzaSyB4xD7fB993xNwqzBwF0vFpV3Qg_N9UTTc"></alpaca-map>
       <!-- 
     // USAGE Step 2 - END
      -->

--- a/public/index.html
+++ b/public/index.html
@@ -41,6 +41,6 @@
       </p>
     </div>
 
-    <script type="module" src="/build/alpaca-map.js"></script>
+    <script type="module" src="/build/src/alpaca-map.js"></script>
   </body>
 </html>

--- a/src/alpaca-map.js
+++ b/src/alpaca-map.js
@@ -1,6 +1,7 @@
 import { compareExact, compareSparse } from "./utils.js";
 import { LitElement, html, css } from "lit";
 import { MarkerClusterer } from "@googlemaps/markerclusterer";
+
 import STYLED_MAP_TYPE from "./styles-map.js";
 import stylesGoogle from "./styles-google.js";
 import "./alpaca-map-marker.js";
@@ -18,8 +19,19 @@ export default class AlpacaMap extends LitElement {
     stylesGoogle,
     css`
       /********* Overall layout *********/
-
       :host {
+        background-color: white;
+        display: inline-block;
+        border: 1px solid black;
+        height: 500px;
+        width: 600px;
+
+        display: grid;
+        grid-template-columns: 1fr;
+        grid-template-rows: 85px 1fr 80px;
+        grid-column-gap: 0px;
+        grid-row-gap: 0px;
+
         /* Ref: https://developer.mozilla.org/en-US/docs/Learn/CSS/CSS_layout/Responsive_Design#responsive_typography */
         /* font-size: calc(1.5rem + 3vw); */
 
@@ -55,13 +67,30 @@ export default class AlpacaMap extends LitElement {
         --public-farm: var(--green);
       }
 
-      .web-component-container {
-        border: 1px solid black;
+      /* Custom minimalistic scrollbar */
+      ::-webkit-scrollbar {
+        width: 20px;
+      }
+
+      ::-webkit-scrollbar-track {
+        background-color: transparent;
+      }
+
+      ::-webkit-scrollbar-thumb {
+        background-color: #d6dee1;
+        border-radius: 20px;
+        border: 6px solid transparent;
+        background-clip: content-box;
+      }
+
+      ::-webkit-scrollbar-thumb:hover {
+        background-color: #a8bbbf;
       }
 
       .header-container {
         background-color: white;
-        padding: 0.5em;
+        margin: 0.5em;
+        overflow: hidden;
       }
 
       .map-container {
@@ -119,12 +148,11 @@ export default class AlpacaMap extends LitElement {
         flex-direction: row;
         flex-wrap: nowrap;
         overflow: auto;
-
-        width: 100%;
         box-sizing: border-box;
       }
 
       .toggle {
+        flex: 0 0 auto;
         color: #006ce4;
         background-color: rgba(0, 108, 228, 0.06);
         border: solid #006ce4 0.15em;
@@ -161,7 +189,7 @@ export default class AlpacaMap extends LitElement {
 
       #map {
         height: 100%;
-        width: auto;
+        width: 100%;
         background-color: var(--pale-blue);
       }
     `,
@@ -226,16 +254,21 @@ export default class AlpacaMap extends LitElement {
   // When element has rendered markup in the DOM firstUpdated() is called
   async firstUpdated() {
     async function fetchFarms(dataSource) {
-      const response = await fetch(dataSource);
-      const farms = await response.json();
-      console.log("farms", farms);
+      let arr = [];
+      try {
+        const response = await fetch(dataSource);
+        const farms = await response.json();
+        console.log("farms", farms);
+  
+        arr = farms?.items || [];
+      } catch(error) {
 
-      return farms?.items || [];
+      }
+      return arr;
     }
 
     // Set default location
     const center = { lat: this.centerLat, lng: this.centerLng };
-    console.log("center", center);
 
     // Load data to populate the map
     this.farms = await fetchFarms(this.dataSource);
@@ -372,126 +405,122 @@ export default class AlpacaMap extends LitElement {
 
     this.cluster.clearMarkers();
     this.cluster.addMarkers(markers);
-
-    console.log("markers.length", markers.length);
   }
 
   render() {
     return html`
-      <section class="web-component-container">
-        <header class="header-container">
-          <form id="form" @change="${this._filterMarkers}">
-            <div class="toggle-group">
-              <span class="toggle">
-                <input type="checkbox" id="public" name="public" checked />
-                <label for="public">
-                  <alpaca-map-icon icon="houseFlag"></alpaca-map-icon>Public
-                  farms</label
-                >
-              </span>
+      <header class="header-container">
+        <form id="form" @change="${this._filterMarkers}">
+          <div class="toggle-group">
+            <span class="toggle">
+              <input type="checkbox" id="public" name="public" checked />
+              <label for="public">
+                <alpaca-map-icon icon="houseFlag"></alpaca-map-icon>Public
+                farms</label
+              >
+            </span>
 
-              <span class="toggle">
-                <input type="checkbox" id="private" name="private" checked />
-                <label for="private"
-                  ><alpaca-map-icon icon="key"></alpaca-map-icon>Private
-                  farms</label
-                >
-              </span>
+            <span class="toggle">
+              <input type="checkbox" id="private" name="private" checked />
+              <label for="private"
+                ><alpaca-map-icon icon="key"></alpaca-map-icon>Private
+                farms</label
+              >
+            </span>
 
-              <span class="toggle">
-                <input type="checkbox" id="alpacaSales" name="alpacaSales" />
-                <label for="alpacaSales"
-                  ><alpaca-map-icon icon="handShake"></alpaca-map-icon>Alpaca
-                  sales</label
-                >
-              </span>
+            <span class="toggle">
+              <input type="checkbox" id="alpacaSales" name="alpacaSales" />
+              <label for="alpacaSales"
+                ><alpaca-map-icon icon="handShake"></alpaca-map-icon>Alpaca
+                sales</label
+              >
+            </span>
 
-              <span class="toggle">
-                <input
-                  type="checkbox"
-                  id="alpacaWalking"
-                  name="alpacaWalking"
-                />
-                <label for="alpacaWalking"
-                  ><alpaca-map-icon icon="personHiking"></alpaca-map-icon>Alpaca
-                  walking</label
-                >
-              </span>
+            <span class="toggle">
+              <input
+                type="checkbox"
+                id="alpacaWalking"
+                name="alpacaWalking"
+              />
+              <label for="alpacaWalking"
+                ><alpaca-map-icon icon="personHiking"></alpaca-map-icon>Alpaca
+                walking</label
+              >
+            </span>
 
-              <span class="toggle">
-                <input type="checkbox" id="bookable" name="bookable" />
-                <label for="bookable"
-                  ><alpaca-map-icon icon="calendarCheck"></alpaca-map-icon
-                  >Bookable</label
-                >
-              </span>
+            <span class="toggle">
+              <input type="checkbox" id="bookable" name="bookable" />
+              <label for="bookable"
+                ><alpaca-map-icon icon="calendarCheck"></alpaca-map-icon
+                >Bookable</label
+              >
+            </span>
 
-              <span class="toggle">
-                <input type="checkbox" id="shop" name="shop" />
-                <label for="shop"
-                  ><alpaca-map-icon icon="store"></alpaca-map-icon>Shop</label
-                >
-              </span>
+            <span class="toggle">
+              <input type="checkbox" id="shop" name="shop" />
+              <label for="shop"
+                ><alpaca-map-icon icon="store"></alpaca-map-icon>Shop</label
+              >
+            </span>
 
-              <span class="toggle">
-                <input
-                  type="checkbox"
-                  id="overnightStay"
-                  name="overnightStay"
-                />
-                <label for="overnightStay"
-                  ><alpaca-map-icon icon="bed"></alpaca-map-icon>Overnight
-                  stay</label
-                >
-              </span>
+            <span class="toggle">
+              <input
+                type="checkbox"
+                id="overnightStay"
+                name="overnightStay"
+              />
+              <label for="overnightStay"
+                ><alpaca-map-icon icon="bed"></alpaca-map-icon>Overnight
+                stay</label
+              >
+            </span>
 
-              <span class="toggle">
-                <input type="checkbox" id="studServices" name="studServices" />
-                <label for="studServices"
-                  ><alpaca-map-icon icon="mars"></alpaca-map-icon>Stud
-                  services</label
-                >
-              </span>
-            </div>
-          </form>
-        </header>
-        <div class="map-container">
-          <div id="map"></div>
+            <span class="toggle">
+              <input type="checkbox" id="studServices" name="studServices" />
+              <label for="studServices"
+                ><alpaca-map-icon icon="mars"></alpaca-map-icon>Stud
+                services</label
+              >
+            </span>
+          </div>
+        </form>
+      </header>
+      
+      <div class="map-container" id="map"></div>
+
+      <footer class="footer-container">
+        <div>
+          <a
+            href="https://www.alpaca.life"
+            target="_blank"
+            data-testid="link-logo"
+            ><img
+              src="/assets/images/alpaca.life.logo.png"
+              width="100px"
+              height="100px"
+              alt="Alpaca Life logo"
+          /></a>
         </div>
-        <footer class="footer-container">
-          <div>
-            <a
-              href="https://www.alpaca.life"
-              target="_blank"
-              data-testid="link-logo"
-              ><img
-                src="/assets/images/alpaca.life.logo.png"
-                width="100px"
-                height="100px"
-                alt="Alpaca Life logo"
-            /></a>
-          </div>
-          <div class="footer-message">
-            Find alpacas,<br />
-            farms and more:<br />
-            <a href="https://www.alpaca.life" target="_blank"
-              >www.alpaca.life</a
-            >
-          </div>
-          <div>
-            <a
-              href="https://ko-fi.com/anitalipsky"
-              target="_blank"
-              data-testid="link-support"
-              ><img
-                id="ko-fi"
-                src="/assets/images/kofi_bg_tag_white.svg"
-                width="100px"
-                alt="Buy me a ko-fi"
-            /></a>
-          </div>
-        </footer>
-      </section>
+        <div class="footer-message">
+          Find alpacas,<br />
+          farms and more:<br />
+          <a href="https://www.alpaca.life" target="_blank"
+            >www.alpaca.life</a
+          >
+        </div>
+        <div>
+          <a
+            href="https://ko-fi.com/anitalipsky"
+            target="_blank"
+            data-testid="link-support"
+            ><img
+              id="ko-fi"
+              src="/assets/images/kofi_bg_tag_white.svg"
+              width="100px"
+              alt="Buy me a ko-fi"
+          /></a>
+        </div>
+      </footer>
     `;
   }
 }


### PR DESCRIPTION
This adds a build script for adjusting the dependencies when publishing this module.

The main problem is that the [cluster module is not correctly exporting](https://github.com/googlemaps/js-markerclusterer/pull/909) itself. This problem makes it "impossible" for us to publish this module and have someone else use it (it will break).

The solution to this is that we need to transform how the cluster module export itself before we can transform this. The added build script does this and makes it possible to publish this module so it can be used in other projects.

I've also adjusted some methods and css in the module to be more suitable for use in a different project.